### PR TITLE
Fixes for macOS

### DIFF
--- a/src/Eto.Veldrid.WinForms/Eto.Veldrid.WinForms.csproj
+++ b/src/Eto.Veldrid.WinForms/Eto.Veldrid.WinForms.csproj
@@ -1,4 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project>
+
+  <PropertyGroup>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT' and $([System.Version]::Parse($([MSBuild]::ValueOrDefault('$(VisualStudioVersion)', '1.0')))) &gt;= $([System.Version]::Parse('16.0'))">true</HaveWindowsDesktopSdk>
+  </PropertyGroup>
+
+  <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+  <Import Condition="'$(HaveWindowsDesktopSdk)' == 'true'" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Project="Sdk.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
@@ -12,5 +19,8 @@
   <ItemGroup>
     <PackageReference Include="Eto.Platform.Windows" Version="2.5.0" />
   </ItemGroup>
+
+  <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+  <Import Condition="'$(HaveWindowsDesktopSdk)' == 'true'" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Project="Sdk.targets" />
 
 </Project>

--- a/src/Eto.Veldrid.Wpf/Eto.Veldrid.Wpf.csproj
+++ b/src/Eto.Veldrid.Wpf/Eto.Veldrid.Wpf.csproj
@@ -1,4 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project>
+
+  <PropertyGroup>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT' and $([System.Version]::Parse($([MSBuild]::ValueOrDefault('$(VisualStudioVersion)', '1.0')))) &gt;= $([System.Version]::Parse('16.0'))">true</HaveWindowsDesktopSdk>
+  </PropertyGroup>
+
+  <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+  <Import Condition="'$(HaveWindowsDesktopSdk)' == 'true'" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Project="Sdk.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
@@ -29,5 +36,9 @@
     <Reference Include="WindowsBase" />
     <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
+
+  <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+  <Import Condition="'$(HaveWindowsDesktopSdk)' == 'true'" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Project="Sdk.targets" />
+
 
 </Project>

--- a/src/Eto.Veldrid/Eto.Veldrid.csproj
+++ b/src/Eto.Veldrid/Eto.Veldrid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <RootNamespace>Eto.Veldrid</RootNamespace>
     <Title>Eto.Veldrid</Title>

--- a/src/Eto.Veldrid/VeldridSurface.cs
+++ b/src/Eto.Veldrid/VeldridSurface.cs
@@ -1,4 +1,5 @@
-﻿using Eto.Forms;
+﻿using Eto.Drawing;
+using Eto.Forms;
 using System;
 using Veldrid;
 using Veldrid.OpenGL;
@@ -180,7 +181,16 @@ namespace Eto.Veldrid
 			OnVeldridInitialized(EventArgs.Empty);
 		}
 
-		protected virtual void OnDraw(EventArgs e) => Properties.TriggerEvent(DrawEvent, this, e);
+		protected virtual void OnDraw(EventArgs e)
+		{
+			if (_resizeEvent != null)
+			{
+				OnResize(_resizeEvent);
+				_resizeEvent = null;
+			}
+
+			Properties.TriggerEvent(DrawEvent, this, e);
+		}
 
 		protected virtual void OnResize(ResizeEventArgs e)
 		{
@@ -191,6 +201,8 @@ namespace Eto.Veldrid
 
 			Properties.TriggerEvent(ResizeEvent, this, e);
 		}
+
+		ResizeEventArgs _resizeEvent;
 
 		protected virtual void OnVeldridInitialized(EventArgs e) => Properties.TriggerEvent(VeldridInitializedEvent, this, e);
 
@@ -203,7 +215,7 @@ namespace Eto.Veldrid
 				return;
 			}
 
-			OnResize(new ResizeEventArgs(RenderWidth, RenderHeight));
+			_resizeEvent = new ResizeEventArgs(RenderWidth, RenderHeight);
 		}
 	}
 }

--- a/test/TestEtoVeldrid.Mac/Program.cs
+++ b/test/TestEtoVeldrid.Mac/Program.cs
@@ -1,4 +1,5 @@
-﻿using Eto.Forms;
+﻿using Eto;
+using Eto.Forms;
 using Eto.Veldrid;
 using System;
 using System.Diagnostics;
@@ -11,7 +12,7 @@ namespace TestEtoVeldrid.Mac
 		[STAThread]
 		public static void Main(string[] args)
 		{
-			VeldridSurface.InitializeOpenTK();
+			//VeldridSurface.InitializeOpenTK();
 
 			var platform = new Eto.Mac.Platform();
 
@@ -30,7 +31,7 @@ namespace TestEtoVeldrid.Mac
 			// other hand, it returns the directory containing the .app..
 			new Application(platform).Run(new MainForm(
 				Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName),
-				Path.Combine("..", "Resources", "shaders")));
+				Path.Combine(EtoEnvironment.GetFolderPath(EtoSpecialFolder.ApplicationResources), "shaders")));
 		}
 	}
 }

--- a/test/TestEtoVeldrid.Mac/TestEtoVeldrid.Mac64.csproj
+++ b/test/TestEtoVeldrid.Mac/TestEtoVeldrid.Mac64.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <DefineConstants>MONOMAC</DefineConstants>
+    <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestEtoVeldrid.WinForms/TestEtoVeldrid.WinForms.csproj
+++ b/test/TestEtoVeldrid.WinForms/TestEtoVeldrid.WinForms.csproj
@@ -1,4 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project>
+
+  <PropertyGroup>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT' and $([System.Version]::Parse($([MSBuild]::ValueOrDefault('$(VisualStudioVersion)', '1.0')))) &gt;= $([System.Version]::Parse('16.0'))">true</HaveWindowsDesktopSdk>
+  </PropertyGroup>
+
+  <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+  <Import Condition="'$(HaveWindowsDesktopSdk)' == 'true'" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Project="Sdk.props" />
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -14,5 +21,8 @@
   <ItemGroup>
     <PackageReference Include="Eto.Platform.Windows" Version="2.5.0" />
   </ItemGroup>
+
+  <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+  <Import Condition="'$(HaveWindowsDesktopSdk)' == 'true'" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Project="Sdk.targets" />
 
 </Project>

--- a/test/TestEtoVeldrid.Wpf/TestEtoVeldrid.Wpf.csproj
+++ b/test/TestEtoVeldrid.Wpf/TestEtoVeldrid.Wpf.csproj
@@ -1,4 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project>
+
+  <PropertyGroup>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT' and $([System.Version]::Parse($([MSBuild]::ValueOrDefault('$(VisualStudioVersion)', '1.0')))) &gt;= $([System.Version]::Parse('16.0'))">true</HaveWindowsDesktopSdk>
+  </PropertyGroup>
+
+  <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+  <Import Condition="'$(HaveWindowsDesktopSdk)' == 'true'" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Project="Sdk.props" />
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -14,12 +21,15 @@
 
   <ItemGroup>
     <PackageReference Include="Eto.Platform.Wpf" Version="2.5.0" />
-    
+
     <!-- Please note that version 3.6.0 is the newest version of this toolkit
     that has licensing terms permitting use in commercial projects.
     https://github.com/picoe/Eto/issues/1544
     https://github.com/xceedsoftware/wpftoolkit/issues/1557 -->
     <PackageReference Include="Extended.Wpf.Toolkit" Version="[3.6.0]" />
   </ItemGroup>
+
+  <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+  <Import Condition="'$(HaveWindowsDesktopSdk)' == 'true'" Sdk="Microsoft.NET.Sdk.WindowsDesktop" Project="Sdk.targets" />
 
 </Project>

--- a/test/TestEtoVeldrid/TestEtoVeldrid.csproj
+++ b/test/TestEtoVeldrid/TestEtoVeldrid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <RootNamespace>TestEtoVeldrid</RootNamespace>
     <Title>TestEtoVeldrid</Title>


### PR DESCRIPTION
- Resize should happen during the Draw event
- Use CVDisplayLink on macOS to render the frame
- Fix compile errors when compiling on macOS or linux

Hey @ItEndsWithTens, this should get things working on macOS:

<img width="719" alt="Screen Shot 2020-04-27 at 12 04 57 AM" src="https://user-images.githubusercontent.com/367446/80350336-694c5880-8825-11ea-8df7-277f8ec0bc40.png">

I had to change the OnResize to be called during the next Draw event so it wouldn't crash when resizing the control.  This appears to work on all platforms.

I also changed the .csproj's for WPF and WinForms to import Microsoft.NET.Sdk.WindowsDesktop conditionally as doing a nuget restore fails on !windows without it, which means you wouldn't be able to build on anything but windows unless you created a separate sln excluding those projects.

Thanks again for your efforts with this!  It's really cool to see these controls available for Eto.Forms.   Please let me know if you need help getting these published as nuget packages and/or creating the XamMac2 backend.